### PR TITLE
fix ACH retry

### DIFF
--- a/classes/class-gf-securesubmit.php
+++ b/classes/class-gf-securesubmit.php
@@ -1007,7 +1007,13 @@ class GFSecureSubmit extends GFPaymentAddOn
         $this->isCC = false;
         foreach ($validation_result['form']['fields'] as $field) {
             $current_page = GFFormDisplay::get_source_page($validation_result['form']['id']);
-            $field_on_curent_page = $current_page > 0 && $field['pageNumber'] == $current_page;
+
+            if ($current_page > 0) {
+                $field_on_curent_page = $field['pageNumber'] == $current_page;
+            } else {
+                $field_on_curent_page = true;
+            }
+
             $fieldType = GFFormsModel::get_input_type($field);
 
             if ($fieldType == 'hpsACH' && $field_on_curent_page) {


### PR DESCRIPTION
for some reason $current_page gets set to "0" when 1009 runs following a failed ACH payment attempt. This results in 1013 perma-failing because $field_on_curent_page will always be false. The only existing workaround is to clear browser cache and the like so that 1009 will evaluate fresh.