### PR TITLE
update processingDateInfo in semi-monthly

### DIFF
--- a/classes/class-gf-securesubmit.php
+++ b/classes/class-gf-securesubmit.php
@@ -2551,12 +2551,22 @@ class GFSecureSubmit extends GFPaymentAddOn
         $schedule->totalAmount = new HpsPayPlanAmount(HpsInputValidation::checkAmount($payment_amount));
         $schedule->frequency = $this->validPayPlanCycle($feed);
 
-        /*Conditional; Required if Frequency is Monthly, Bi-Monthly, Quarterly, Semi-Annually, or Semi-Monthly.*/
-        if (!in_array($schedule->frequency, array(HpsPayPlanScheduleFrequency::WEEKLY,HpsPayPlanScheduleFrequency::BIWEEKLY, HpsPayPlanScheduleFrequency::ANNUALLY))) {
+        /*Conditional; Required if Frequency is Monthly, Bi-Monthly, Quarterly, Semi-Annually.*/
+        if (!in_array($schedule->frequency, array(
+            HpsPayPlanScheduleFrequency::WEEKLY,
+            HpsPayPlanScheduleFrequency::BIWEEKLY,
+            HpsPayPlanScheduleFrequency::SEMIMONTHLY,
+            HpsPayPlanScheduleFrequency::ANNUALLY
+        ))) {
             $schedule->processingDateInfo = date("d", strtotime(date('d-m-Y')));
         }
 
         $schedule->startDate = $this->getStartDateInfo($schedule->frequency, $trial_period_days);
+
+        if (HpsPayPlanScheduleFrequency::SEMIMONTHLY === $schedule->frequency) {
+            $schedule->processingDateInfo = $schedule->startDate;
+        }
+
         $numberOfPayments = $feed['meta']['recurringTimes'] === '0'
             ? HpsPayPlanScheduleDuration::ONGOING
             : HpsPayPlanScheduleDuration::LIMITED_NUMBER;

--- a/gravityforms-securesubmit.php
+++ b/gravityforms-securesubmit.php
@@ -3,12 +3,12 @@
  * Plugin Name: Heartland Secure Submit Addon for Gravity Forms
  * Plugin URI: https://developer.heartlandpaymentsystems.com/securesubmit
  * Description: Integrates Gravity Forms with SecureSubmit, enabling end users to purchase goods and services through Gravity Forms.
- * Version: 1.4.3
+ * Version: 1.4.4
  * Author: SecureSubmit
  * Author URI: https://developer.heartlandpaymentsystems.com/securesubmit
  */
 
-define('GF_SECURESUBMIT_VERSION', '1.4.3');
+define('GF_SECURESUBMIT_VERSION', '1.4.4');
 
 add_action('gform_loaded', array('GF_SecureSubmit_Bootstrap', 'load'), 5);
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,9 @@ Features of SecureSubmit:
 
 
 == Changelog ==
+= 1.4.4 =
+* Fix: Recurring schedules with frequency 'semi-monthly' had incorrect parameters included in the request, causing it to fail.
+
 = 1.4.3 =
 * Fix: Page won't allow new ACH transaction attempt after a decline/fail
 


### PR DESCRIPTION
when a schedule is semi-monthly, the only accepted values for processingDateInfo are `First` and `Last`.
we're removing the specific date calculation and replace it with the start date info when frequency is semi-monthly