### PR TITLE
updated_tested-up-to_to_5.5.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Heartland Secure Submit Addon for Gravity Forms ===
 Contributors: markhagan
 Tags: gravity, forms, gravityforms, heartland, payment, systems, gateway, token, tokenize
-Tested up to: 5.2
+Tested up to: 5.5.1
 Stable tag: trunk
 License: GPLv2
 License URI: https://github.com/hps/heartland-gravity-forms-addon/blob/master/LICENSE.md


### PR DESCRIPTION
Plugin is tested and verified compatible with WordPress version 5.5.1 & Gravity Forms version 2.4.20